### PR TITLE
Compatibility for osgDB::writeNodeFile

### DIFF
--- a/viz/RobotVisualization.cpp
+++ b/viz/RobotVisualization.cpp
@@ -152,7 +152,7 @@ void RobotVisualization::setFrameEnabled(QString segment_name, bool value, doubl
         it->second->setPluginEnabled(true);
     }
     else{
-        it->second->setSize(0);
+        it->second->setSize(1e-10);
         it->second->setPluginEnabled(false);
     }
 }


### PR DESCRIPTION
When frames are disabled, set them to a really small size sinstead of… zero. setSize(0); was causing trouble (ugly, large blobs) with osg::osgDB::writeNodeFile (see #8).

This is a workaround for the problem.