### PR TITLE
from modelfile property call setmodelfile on write

### DIFF
--- a/viz/RobotVisualization.cpp
+++ b/viz/RobotVisualization.cpp
@@ -82,6 +82,7 @@ void RobotVisualization::hideSegmentText(QString link_name){
 
 void RobotVisualization::setModelFile(QString modelFile)
 {
+    LOG_INFO("setting model file to  %s", modelFile.toLatin1().data());
     loadFromFile(modelFile);
 }
 

--- a/viz/RobotVisualization.hpp
+++ b/viz/RobotVisualization.hpp
@@ -19,7 +19,7 @@ class RobotVisualization
         , boost::noncopyable
 {
     Q_OBJECT
-    Q_PROPERTY(QString modelFile READ modelFile WRITE loadFromFile)
+    Q_PROPERTY(QString modelFile READ modelFile WRITE setModelFile)
     Q_PROPERTY(bool framesEnabled READ areFramesEnabled WRITE setFramesEnabled)
     Q_PROPERTY(double jointsSize READ getJointsSize WRITE setJointsSize)
     Q_PROPERTY(bool followModelWithCamera READ getFollowModelWithCamera WRITE setFollowModelWithCamera)


### PR DESCRIPTION
Note: double loading of model started with commit 7c5087bd1c6f687c766a7aea1a57bc49984791a1, where the emit propertychanged was uncommented, but the problem is actually in vizkit3d setting the modelfile property again then. Maybe we should check here if the modelFile actually changed, and not blindly reload it?