### PR TITLE
implement mesh caching

### DIFF
--- a/viz/RobotModel.h
+++ b/viz/RobotModel.h
@@ -58,6 +58,9 @@ public:
  */
     OSGSegment(KDL::Segment seg, bool useVBO);
 
+    /** Clear the internal mesh file loading cache */
+    static void clearMeshCache();
+
     /**
      * @brief Set position of joint
      *
@@ -170,6 +173,8 @@ private:
     osg::ref_ptr<osg::Geode> text_label_geode_;
     bool isSelected_; /**< Selection state */
     bool useVBO_; /**< Whether rendering should use VBOs */
+
+    static std::map<std::string, osg::ref_ptr<osg::Node>> meshCache;
 
     friend class InteractionHandler;
     friend class OSGSegmentCallback;

--- a/viz/RobotModel.h
+++ b/viz/RobotModel.h
@@ -174,6 +174,8 @@ private:
     bool isSelected_; /**< Selection state */
     bool useVBO_; /**< Whether rendering should use VBOs */
 
+    /** Caches each loaded mesh indexec by it's filename to prevent double
+     *  loading the fiels and avoid duplicates in osg scene */
     static std::map<std::string, osg::ref_ptr<osg::Node>> meshCache;
 
     friend class InteractionHandler;

--- a/viz/RobotVisualization.cpp
+++ b/viz/RobotVisualization.cpp
@@ -34,6 +34,11 @@ RobotVisualization::~RobotVisualization()
     deleteFrameVisualizers();
 }
 
+void RobotVisualization::clearMeshCache()
+{
+    OSGSegment::clearMeshCache();
+}
+
 void RobotVisualization::handlePropertyChanged(QString property){
     if(property == "frame"){
         std::vector<std::string>::iterator it;

--- a/viz/RobotVisualization.hpp
+++ b/viz/RobotVisualization.hpp
@@ -33,6 +33,8 @@ public:
     void setModelFile(QString modelFile);
     QString modelFile() const;
 
+    Q_INVOKABLE void clearMeshCache();
+
     Q_INVOKABLE void updateData(base::samples::Joints const &sample)
     {vizkit3d::Vizkit3DPlugin<base::samples::Joints>::updateData(sample);}
 


### PR DESCRIPTION
This ensures we load a given mesh file only once. It is an optimization
both on the loading side, and on the rendering side (since OSG shares
buffers between the various instances)