### PR TITLE
automatically reset camera on startup

### DIFF
--- a/bin/rock-roboviz
+++ b/bin/rock-roboviz
@@ -229,13 +229,17 @@ else
     end
 end
 
+view3d.setCameraManipulator("Trackball")
+view3d.setCameraLookAt(0,0,0)
+view3d.setCameraEye(4, 4, 3)
+
 if live
     if hostname
         Orocos::CORBA.name_service.ip = hostname
     end
     Orocos.initialize
 
-    state_tasks.each do | task_name, port_name | 
+    state_tasks.each do | task_name, port_name |
         task = discover_and_connect_to_port task_name, port_name,
             filter:  ->(port) { port.is_a?(Orocos::OutputPort) and p.type == Types::Base::Samples::Joints },
             handler: ->(port) { port.on_data { |sample| vis_gui.updateData(sample) } }
@@ -254,7 +258,7 @@ if live
 
 elsif use_test_gui
     ctrl_gui.enabled = true
-    ctrl_gui.connect(SIGNAL('sendSignal()')) do 
+    ctrl_gui.connect(SIGNAL('sendSignal()')) do
         sample = ctrl_gui.getJoints()
         vis_gui.updateData(sample)
     end
@@ -263,5 +267,3 @@ end
 
 main.show
 Vizkit.exec
-
-


### PR DESCRIPTION
On Ubuntu20.04 the robot model is no longer visible after starting. Resetting the camera like this patch does help.

Nevertheless the problem might be rooted in vizkit3d or somewhere else. Any opinions/additional info on this topic?