### PR TITLE
Add Opacity setting and change specular color

### DIFF
--- a/viz/OSGSegment.cpp
+++ b/viz/OSGSegment.cpp
@@ -290,10 +290,10 @@ osg::ref_ptr<osg::Group> OSGSegment::createVisual(urdf::VisualSharedPtr visual, 
                                                                     visual->material->color.g,
                                                                     visual->material->color.b,
                                                                     visual->material->color.a));
-            nodematerial->setSpecular(osg::Material::FRONT,osg::Vec4(0.2,
-                                                                     0.2,
-                                                                     0.2,
-                                                                     1));
+            nodematerial->setSpecular(osg::Material::FRONT,osg::Vec4(visual->material->color.r,
+                                                                    visual->material->color.g,
+                                                                    visual->material->color.b,
+                                                                     0));
 
             //Attaching the newly defined state set object to the node state set
             nodess->setAttribute(nodematerial.get());

--- a/viz/OSGSegment.cpp
+++ b/viz/OSGSegment.cpp
@@ -291,9 +291,9 @@ osg::ref_ptr<osg::Group> OSGSegment::createVisual(urdf::VisualSharedPtr visual, 
                                                                     visual->material->color.b,
                                                                     visual->material->color.a));
             nodematerial->setSpecular(osg::Material::FRONT,osg::Vec4(visual->material->color.r,
-                                                                    visual->material->color.g,
-                                                                    visual->material->color.b,
-                                                                     0));
+                                                                     visual->material->color.g,
+                                                                     visual->material->color.b,
+                                                                     visual->material->color.a));
 
             //Attaching the newly defined state set object to the node state set
             nodess->setAttribute(nodematerial.get());

--- a/viz/RobotVisualization.hpp
+++ b/viz/RobotVisualization.hpp
@@ -6,6 +6,7 @@
 #include <base/samples/Joints.hpp>
 #include <base/samples/RigidBodyState.hpp>
 #include <QMessageBox>
+#include <osg/NodeVisitor>
 #include "RobotModel.h"
 
 namespace vizkit3d
@@ -28,6 +29,7 @@ class RobotVisualization
     Q_PROPERTY(bool showVisuals READ areVisualsEnabled WRITE setVisualsEnabled)
     Q_PROPERTY(bool showCollision READ areCollisionsEnabled WRITE setCollisionsEnabled)
     Q_PROPERTY(bool showInertias READ areInertiasEnabled WRITE setInertiasEnabled)
+    Q_PROPERTY(double opacity READ getOpacity WRITE setOpacity)
 
 public:
     RobotVisualization();
@@ -98,6 +100,8 @@ public slots:
     void setCollisionsEnabled(bool value);
     bool areInertiasEnabled() const;
     void setInertiasEnabled(bool value);
+    double getOpacity() const;
+    void setOpacity(double value);
     QQuaternion getRotation(QString source_frame, QString target_frame);
     QVector3D getTranslation(QString source_frame, QString target_frame);
 
@@ -121,6 +125,18 @@ protected:
     void deleteFrameVisualizers();
 
 private:
+
+    class TransparencyVisitor : public osg::NodeVisitor {
+     public:
+        explicit TransparencyVisitor(double transparency):transparency(1.0-transparency) {}
+        virtual ~TransparencyVisitor() {}
+
+        void apply(osg::Node& node);
+
+     private:
+        double transparency;
+    };
+
     struct Data;
     bool framesEnabled_ = false;
     bool followModelWithCamera_;
@@ -128,6 +144,7 @@ private:
     bool visualsEnabled_ = true;
     bool collisionsEnabled_ = false;
     bool inertiasEnabled_ = false;
+    double opacity_;
     double joints_size;
     Data* p;
     QString _modelFile;


### PR DESCRIPTION
Call setTransparency on any node with a material in the visualizer using a node Visitor.

Also changed the specular color to have a nicer looking model.

First we discussed changing the osg_visual var in the OSGSegments, but there are multiple osg_visual generated, so i'd have to iterate. When doing this via a nodeVisitor, this can even be done in the RobotVisualization.cpp on top level. This also has the advantage, that the opacity is also applied to future additions to the graph.

