### PR TITLE
FIX: change type of wcMatrix

### DIFF
--- a/viz/OSGHelpers.hpp
+++ b/viz/OSGHelpers.hpp
@@ -172,7 +172,7 @@ public:
     }
 private:
     bool done;
-    osg::Matrix* wcMatrix;
+    osg::Matrixd* wcMatrix;
 };
 
 // Given a valid node placed in a scene under a transform, return the


### PR DESCRIPTION
Error:
gui/robot_model/viz/OSGHelpers.hpp: In constructor ‘getWorldCoordOfNodeVisitor::getWorldCoordOfNodeVisitor()’:gui/robot_model/viz/OSGHelpers.hpp: In constructor ‘getWorldCoordOfNodeVisitor::getWorldCoordOfNodeVisitor()’:

gui/robot_model/viz/OSGHelpers.hpp:155:19: error: cannot convert ‘osg::Matrixd*’ to ‘osg::Matrix*’ {aka ‘osg::Matrixf*’} in assignment